### PR TITLE
Fix when consuming from an empty topic

### DIFF
--- a/src/main/java/io/managed/services/test/cli/CLI.java
+++ b/src/main/java/io/managed/services/test/cli/CLI.java
@@ -329,6 +329,10 @@ public class CLI {
         // consume returns inline Jsons separated by newline, therefore string must be firstly split than read as multiple jsons
         var output = retry(() -> exec(cmd)).stdoutAsString();
 
+        if (output.isEmpty()){
+            return new ArrayList<Record>();
+        }
+        
         // specific separated JSON objects \n}\n which is separator of multiple inline jsons
         String[] lines = output.split("\n\\}\n");
         // append back '}' (i.e. curly bracket) so JSON objects will not miss this end symbol


### PR DESCRIPTION
When no records in the topic returns an empty list.